### PR TITLE
Revised the usage of correlation GUID's.

### DIFF
--- a/src/Altinn.Dan.Plugin.Banking/Clients/KAR.cs
+++ b/src/Altinn.Dan.Plugin.Banking/Clients/KAR.cs
@@ -9,15 +9,15 @@ namespace Altinn.Dan.Plugin.Banking.Clients
 {
     public partial class KAR
     {
-        public async Task<KARResponse> Get(string ssn, string mpToken, string fromDate, string toDate)
+        public async Task<KARResponse> Get(string ssn, string mpToken, string fromDate, string toDate, Guid accountInfoRequestID, Guid correlationID)
         {
-            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", mpToken); 
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", mpToken);
             var header = _httpClient.DefaultRequestHeaders.Authorization;
 
             if (!header.Scheme.Equals("bearer", StringComparison.OrdinalIgnoreCase))
                 throw new Exception($"Invalid auth header {header.Scheme} found for {ssn} in KAR interface");
 
-            return MapToInternal(await GetCustomerRelationAsync(header.Parameter, ssn, Guid.NewGuid(), "Prosjekt OED", Guid.NewGuid(), fromDate, toDate));
+            return MapToInternal(await GetCustomerRelationAsync(header.Parameter, ssn, correlationID, "Prosjekt OED", accountInfoRequestID, fromDate, toDate));
         }
 
         private static KARResponse MapToInternal(ListCustomerRelation listCustomerRelation)

--- a/src/Altinn.Dan.Plugin.Banking/Config/ApplicationSettings.cs
+++ b/src/Altinn.Dan.Plugin.Banking/Config/ApplicationSettings.cs
@@ -7,7 +7,7 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace Altinn.Dan.Plugin.Banking.Config
 {
-    public class ApplicationSettings 
+    public class ApplicationSettings
     {
         public static ApplicationSettings ApplicationConfig;
         private static X509Certificate2 _altinnCertificate;
@@ -63,16 +63,16 @@ namespace Altinn.Dan.Plugin.Banking.Config
             get { return Convert.ToBoolean(Environment.GetEnvironmentVariable("IsDevelopment")); }
         }
 
-        public string SBankenURI
+        public string SBankenUri
         {
-            get { return Environment.GetEnvironmentVariable("SBankenURI");  }
+            get { return Environment.GetEnvironmentVariable("SBankenUri"); }
         }
 
         public string Sparebank1Uri
         {
             get { return Environment.GetEnvironmentVariable("Sparebank1Uri"); }
         }
-        public string BankAudience 
+        public string BankAudience
         {
             get { return Environment.GetEnvironmentVariable("BankAudience"); }
         }
@@ -84,7 +84,7 @@ namespace Altinn.Dan.Plugin.Banking.Config
 
         public static string KeyVaultClientSecret { get; set; }
 
-        public string ClientId { get;  set; }
+        public string ClientId { get; set; }
 
         public string MaskinportenEndpoint { get; set; }
 
@@ -98,7 +98,7 @@ namespace Altinn.Dan.Plugin.Banking.Config
         {
             get
             {
-                if (IsDevelopment || IsUnitTest) 
+                if (IsDevelopment || IsUnitTest)
                     return _altinnCertificate ?? X509Certificate2Helper.GenerateSelfSignedCertificate();
                 else
                     return _altinnCertificate ?? new CoreKeyVault(ApplicationSettings.KeyVaultName, ApplicationSettings.KeyVaultClientId, ApplicationSettings.KeyVaultClientSecret).GetCertificate(ApplicationSettings.KeyVaultSslCertificate).Result;


### PR DESCRIPTION
During a request to a bank, GUIDs for accountInfoRequestID and correlationID were generated in multiple places. GUIDs are now generated at the top level, passed on, and follow the whole process.